### PR TITLE
[styling] PEP8, Mypy and styling changes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 muts
+Copyright (c) 2016 Kim Koomen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+kociemba = "*"
+opencv-python = "*"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ verify_ssl = true
 [packages]
 kociemba = "*"
 opencv-python = "*"
+numpy = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "40452ab1bbe07d428325f6e8856109bb2e154bba9d2fab89cfddea16f412733d"
+            "sha256": "2203df4d3a4680b42039b53857bf50b44636a0be7dca0189b29d07ab3b096789"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -61,7 +61,7 @@
             "hashes": [
                 "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.18.2"
         },
         "kociemba": {
@@ -74,43 +74,43 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:08308c38e44cc926bdfce99498b21eec1f848d24c302519e64203a8da99a97db",
-                "sha256:09c12096d843b90eafd01ea1b3307e78ddd47a55855ad402b157b6c4862197ce",
-                "sha256:13d166f77d6dc02c0a73c1101dd87fdf01339febec1030bd810dcd53fff3b0f1",
-                "sha256:141ec3a3300ab89c7f2b0775289954d193cc8edb621ea05f99db9cb181530512",
-                "sha256:16c1b388cc31a9baa06d91a19366fb99ddbe1c7b205293ed072211ee5bac1ed2",
-                "sha256:18bed2bcb39e3f758296584337966e68d2d5ba6aab7e038688ad53c8f889f757",
-                "sha256:1aeef46a13e51931c0b1cf8ae1168b4a55ecd282e6688fdb0a948cc5a1d5afb9",
-                "sha256:27d3f3b9e3406579a8af3a9f262f5339005dd25e0ecf3cf1559ff8a49ed5cbf2",
-                "sha256:2a2740aa9733d2e5b2dfb33639d98a64c3b0f24765fed86b0fd2aec07f6a0a08",
-                "sha256:4377e10b874e653fe96985c05feed2225c912e328c8a26541f7fc600fb9c637b",
-                "sha256:448ebb1b3bf64c0267d6b09a7cba26b5ae61b6d2dbabff7c91b660c7eccf2bdb",
-                "sha256:50e86c076611212ca62e5a59f518edafe0c0730f7d9195fec718da1a5c2bb1fc",
-                "sha256:5734bdc0342aba9dfc6f04920988140fb41234db42381cf7ccba64169f9fe7ac",
-                "sha256:64324f64f90a9e4ef732be0928be853eee378fd6a01be21a0a8469c4f2682c83",
-                "sha256:6ae6c680f3ebf1cf7ad1d7748868b39d9f900836df774c453c11c5440bc15b36",
-                "sha256:6d7593a705d662be5bfe24111af14763016765f43cb6923ed86223f965f52387",
-                "sha256:8cac8790a6b1ddf88640a9267ee67b1aee7a57dfa2d2dd33999d080bc8ee3a0f",
-                "sha256:8ece138c3a16db8c1ad38f52eb32be6086cc72f403150a79336eb2045723a1ad",
-                "sha256:9eeb7d1d04b117ac0d38719915ae169aa6b61fca227b0b7d198d43728f0c879c",
-                "sha256:a09f98011236a419ee3f49cedc9ef27d7a1651df07810ae430a6b06576e0b414",
-                "sha256:a5d897c14513590a85774180be713f692df6fa8ecf6483e561a6d47309566f37",
-                "sha256:ad6f2ff5b1989a4899bf89800a671d71b1612e5ff40866d1f4d8bcf48d4e5764",
-                "sha256:c42c4b73121caf0ed6cd795512c9c09c52a7287b04d105d112068c1736d7c753",
-                "sha256:cb1017eec5257e9ac6209ac172058c430e834d5d2bc21961dceeb79d111e5909",
-                "sha256:d6c7bb82883680e168b55b49c70af29b84b84abb161cbac2800e8fcb6f2109b6",
-                "sha256:e452dc66e08a4ce642a961f134814258a082832c78c90351b75c41ad16f79f63",
-                "sha256:e5b6ed0f0b42317050c88022349d994fe72bfe35f5908617512cd8c8ef9da2a9",
-                "sha256:e9b30d4bd69498fc0c3fe9db5f62fffbb06b8eb9321f92cc970f2969be5e3949",
-                "sha256:ec149b90019852266fec2341ce1db513b843e496d5a8e8cdb5ced1923a92faab",
-                "sha256:edb01671b3caae1ca00881686003d16c2209e07b7ef8b7639f1867852b948f7c",
-                "sha256:f0d3929fe88ee1c155129ecd82f981b8856c5d97bcb0d5f23e9b4242e79d1de3",
-                "sha256:f29454410db6ef8126c83bd3c968d143304633d45dc57b51252afbd79d700893",
-                "sha256:fe45becb4c2f72a0907c1d0246ea6449fe7a9e2293bb0e11c4e9a32bb0930a15",
-                "sha256:fedbd128668ead37f33917820b704784aff695e0019309ad446a6d0b065b57e4"
+                "sha256:012426a41bc9ab63bb158635aecccc7610e3eff5d31d1eb43bc099debc979d94",
+                "sha256:06fab248a088e439402141ea04f0fffb203723148f6ee791e9c75b3e9e82f080",
+                "sha256:0eef32ca3132a48e43f6a0f5a82cb508f22ce5a3d6f67a8329c81c8e226d3f6e",
+                "sha256:1ded4fce9cfaaf24e7a0ab51b7a87be9038ea1ace7f34b841fe3b6894c721d1c",
+                "sha256:2e55195bc1c6b705bfd8ad6f288b38b11b1af32f3c8289d6c50d47f950c12e76",
+                "sha256:2ea52bd92ab9f768cc64a4c3ef8f4b2580a17af0a5436f6126b08efbd1838371",
+                "sha256:36674959eed6957e61f11c912f71e78857a8d0604171dfd9ce9ad5cbf41c511c",
+                "sha256:384ec0463d1c2671170901994aeb6dce126de0a95ccc3976c43b0038a37329c2",
+                "sha256:39b70c19ec771805081578cc936bbe95336798b7edf4732ed102e7a43ec5c07a",
+                "sha256:400580cbd3cff6ffa6293df2278c75aef2d58d8d93d3c5614cd67981dae68ceb",
+                "sha256:43d4c81d5ffdff6bae58d66a3cd7f54a7acd9a0e7b18d97abb255defc09e3140",
+                "sha256:50a4a0ad0111cc1b71fa32dedd05fa239f7fb5a43a40663269bb5dc7877cfd28",
+                "sha256:603aa0706be710eea8884af807b1b3bc9fb2e49b9f4da439e76000f3b3c6ff0f",
+                "sha256:6149a185cece5ee78d1d196938b2a8f9d09f5a5ebfbba66969302a778d5ddd1d",
+                "sha256:759e4095edc3c1b3ac031f34d9459fa781777a93ccc633a472a5468587a190ff",
+                "sha256:7fb43004bce0ca31d8f13a6eb5e943fa73371381e53f7074ed21a4cb786c32f8",
+                "sha256:811daee36a58dc79cf3d8bdd4a490e4277d0e4b7d103a001a4e73ddb48e7e6aa",
+                "sha256:8b5e972b43c8fc27d56550b4120fe6257fdc15f9301914380b27f74856299fea",
+                "sha256:99abf4f353c3d1a0c7a5f27699482c987cf663b1eac20db59b8c7b061eabd7fc",
+                "sha256:a0d53e51a6cb6f0d9082decb7a4cb6dfb33055308c4c44f53103c073f649af73",
+                "sha256:a12ff4c8ddfee61f90a1633a4c4afd3f7bcb32b11c52026c92a12e1325922d0d",
+                "sha256:a4646724fba402aa7504cd48b4b50e783296b5e10a524c7a6da62e4a8ac9698d",
+                "sha256:a76f502430dd98d7546e1ea2250a7360c065a5fdea52b2dffe8ae7180909b6f4",
+                "sha256:a9d17f2be3b427fbb2bce61e596cf555d6f8a56c222bd2ca148baeeb5e5c783c",
+                "sha256:ab83f24d5c52d60dbc8cd0528759532736b56db58adaa7b5f1f76ad551416a1e",
+                "sha256:aeb9ed923be74e659984e321f609b9ba54a48354bfd168d21a2b072ed1e833ea",
+                "sha256:c843b3f50d1ab7361ca4f0b3639bf691569493a56808a0b0c54a051d260b7dbd",
+                "sha256:cae865b1cae1ec2663d8ea56ef6ff185bad091a5e33ebbadd98de2cfa3fa668f",
+                "sha256:cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff",
+                "sha256:cf2402002d3d9f91c8b01e66fbb436a4ed01c6498fffed0e4c7566da1d40ee1e",
+                "sha256:d051ec1c64b85ecc69531e1137bb9751c6830772ee5c1c426dbcfe98ef5788d7",
+                "sha256:d6631f2e867676b13026e2846180e2c13c1e11289d67da08d71cacb2cd93d4aa",
+                "sha256:dbd18bcf4889b720ba13a27ec2f2aac1981bd41203b3a3b27ba7a33f88ae4827",
+                "sha256:df609c82f18c5b9f6cb97271f03315ff0dbe481a2a02e56aeb1b1a985ce38e60"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.19.4"
+            "index": "pypi",
+            "version": "==1.19.5"
         },
         "opencv-python": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,156 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "40452ab1bbe07d428325f6e8856109bb2e154bba9d2fab89cfddea16f412733d"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "cffi": {
+            "hashes": [
+                "sha256:00a1ba5e2e95684448de9b89888ccd02c98d512064b4cb987d48f4b40aa0421e",
+                "sha256:00e28066507bfc3fe865a31f325c8391a1ac2916219340f87dfad602c3e48e5d",
+                "sha256:045d792900a75e8b1e1b0ab6787dd733a8190ffcf80e8c8ceb2fb10a29ff238a",
+                "sha256:0638c3ae1a0edfb77c6765d487fee624d2b1ee1bdfeffc1f0b58c64d149e7eec",
+                "sha256:105abaf8a6075dc96c1fe5ae7aae073f4696f2905fde6aeada4c9d2926752362",
+                "sha256:155136b51fd733fa94e1c2ea5211dcd4c8879869008fc811648f16541bf99668",
+                "sha256:1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c",
+                "sha256:1d2c4994f515e5b485fd6d3a73d05526aa0fcf248eb135996b088d25dfa1865b",
+                "sha256:2c24d61263f511551f740d1a065eb0212db1dbbbbd241db758f5244281590c06",
+                "sha256:51a8b381b16ddd370178a65360ebe15fbc1c71cf6f584613a7ea08bfad946698",
+                "sha256:594234691ac0e9b770aee9fcdb8fa02c22e43e5c619456efd0d6c2bf276f3eb2",
+                "sha256:5cf4be6c304ad0b6602f5c4e90e2f59b47653ac1ed9c662ed379fe48a8f26b0c",
+                "sha256:64081b3f8f6f3c3de6191ec89d7dc6c86a8a43911f7ecb422c60e90c70be41c7",
+                "sha256:6bc25fc545a6b3d57b5f8618e59fc13d3a3a68431e8ca5fd4c13241cd70d0009",
+                "sha256:798caa2a2384b1cbe8a2a139d80734c9db54f9cc155c99d7cc92441a23871c03",
+                "sha256:7c6b1dece89874d9541fc974917b631406233ea0440d0bdfbb8e03bf39a49b3b",
+                "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909",
+                "sha256:8d6603078baf4e11edc4168a514c5ce5b3ba6e3e9c374298cb88437957960a53",
+                "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35",
+                "sha256:9f7a31251289b2ab6d4012f6e83e58bc3b96bd151f5b5262467f4bb6b34a7c26",
+                "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b",
+                "sha256:a5ed8c05548b54b998b9498753fb9cadbfd92ee88e884641377d8a8b291bcc01",
+                "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb",
+                "sha256:af5c59122a011049aad5dd87424b8e65a80e4a6477419c0c1015f73fb5ea0293",
+                "sha256:b18e0a9ef57d2b41f5c68beefa32317d286c3d6ac0484efd10d6e07491bb95dd",
+                "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d",
+                "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3",
+                "sha256:c6332685306b6417a91b1ff9fae889b3ba65c2292d64bd9245c093b1b284809d",
+                "sha256:d5ff0621c88ce83a28a10d2ce719b2ee85635e85c515f12bac99a95306da4b2e",
+                "sha256:d9efd8b7a3ef378dd61a1e77367f1924375befc2eba06168b6ebfa903a5e59ca",
+                "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d",
+                "sha256:ebb253464a5d0482b191274f1c8bf00e33f7e0b9c66405fbffc61ed2c839c775",
+                "sha256:ec80dc47f54e6e9a78181ce05feb71a0353854cc26999db963695f950b5fb375",
+                "sha256:f032b34669220030f905152045dfa27741ce1a6db3324a5bc0b96b6c7420c87b",
+                "sha256:f60567825f791c6f8a592f3c6e3bd93dd2934e3f9dac189308426bd76b00ef3b",
+                "sha256:f803eaa94c2fcda012c047e62bc7a51b0bdabda1cad7a92a522694ea2d76e49f"
+            ],
+            "version": "==1.14.4"
+        },
+        "future": {
+            "hashes": [
+                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==0.18.2"
+        },
+        "kociemba": {
+            "hashes": [
+                "sha256:80aecdc3a6c9030832b1d548b4be77ecf08c355928b32d3b3479971fd87e02c4",
+                "sha256:b77435d7b0e93e9c7963e487e8cc3820540bd1c9bb9fe5665999d3a8deac9ee6"
+            ],
+            "index": "pypi",
+            "version": "==1.2.1"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:08308c38e44cc926bdfce99498b21eec1f848d24c302519e64203a8da99a97db",
+                "sha256:09c12096d843b90eafd01ea1b3307e78ddd47a55855ad402b157b6c4862197ce",
+                "sha256:13d166f77d6dc02c0a73c1101dd87fdf01339febec1030bd810dcd53fff3b0f1",
+                "sha256:141ec3a3300ab89c7f2b0775289954d193cc8edb621ea05f99db9cb181530512",
+                "sha256:16c1b388cc31a9baa06d91a19366fb99ddbe1c7b205293ed072211ee5bac1ed2",
+                "sha256:18bed2bcb39e3f758296584337966e68d2d5ba6aab7e038688ad53c8f889f757",
+                "sha256:1aeef46a13e51931c0b1cf8ae1168b4a55ecd282e6688fdb0a948cc5a1d5afb9",
+                "sha256:27d3f3b9e3406579a8af3a9f262f5339005dd25e0ecf3cf1559ff8a49ed5cbf2",
+                "sha256:2a2740aa9733d2e5b2dfb33639d98a64c3b0f24765fed86b0fd2aec07f6a0a08",
+                "sha256:4377e10b874e653fe96985c05feed2225c912e328c8a26541f7fc600fb9c637b",
+                "sha256:448ebb1b3bf64c0267d6b09a7cba26b5ae61b6d2dbabff7c91b660c7eccf2bdb",
+                "sha256:50e86c076611212ca62e5a59f518edafe0c0730f7d9195fec718da1a5c2bb1fc",
+                "sha256:5734bdc0342aba9dfc6f04920988140fb41234db42381cf7ccba64169f9fe7ac",
+                "sha256:64324f64f90a9e4ef732be0928be853eee378fd6a01be21a0a8469c4f2682c83",
+                "sha256:6ae6c680f3ebf1cf7ad1d7748868b39d9f900836df774c453c11c5440bc15b36",
+                "sha256:6d7593a705d662be5bfe24111af14763016765f43cb6923ed86223f965f52387",
+                "sha256:8cac8790a6b1ddf88640a9267ee67b1aee7a57dfa2d2dd33999d080bc8ee3a0f",
+                "sha256:8ece138c3a16db8c1ad38f52eb32be6086cc72f403150a79336eb2045723a1ad",
+                "sha256:9eeb7d1d04b117ac0d38719915ae169aa6b61fca227b0b7d198d43728f0c879c",
+                "sha256:a09f98011236a419ee3f49cedc9ef27d7a1651df07810ae430a6b06576e0b414",
+                "sha256:a5d897c14513590a85774180be713f692df6fa8ecf6483e561a6d47309566f37",
+                "sha256:ad6f2ff5b1989a4899bf89800a671d71b1612e5ff40866d1f4d8bcf48d4e5764",
+                "sha256:c42c4b73121caf0ed6cd795512c9c09c52a7287b04d105d112068c1736d7c753",
+                "sha256:cb1017eec5257e9ac6209ac172058c430e834d5d2bc21961dceeb79d111e5909",
+                "sha256:d6c7bb82883680e168b55b49c70af29b84b84abb161cbac2800e8fcb6f2109b6",
+                "sha256:e452dc66e08a4ce642a961f134814258a082832c78c90351b75c41ad16f79f63",
+                "sha256:e5b6ed0f0b42317050c88022349d994fe72bfe35f5908617512cd8c8ef9da2a9",
+                "sha256:e9b30d4bd69498fc0c3fe9db5f62fffbb06b8eb9321f92cc970f2969be5e3949",
+                "sha256:ec149b90019852266fec2341ce1db513b843e496d5a8e8cdb5ced1923a92faab",
+                "sha256:edb01671b3caae1ca00881686003d16c2209e07b7ef8b7639f1867852b948f7c",
+                "sha256:f0d3929fe88ee1c155129ecd82f981b8856c5d97bcb0d5f23e9b4242e79d1de3",
+                "sha256:f29454410db6ef8126c83bd3c968d143304633d45dc57b51252afbd79d700893",
+                "sha256:fe45becb4c2f72a0907c1d0246ea6449fe7a9e2293bb0e11c4e9a32bb0930a15",
+                "sha256:fedbd128668ead37f33917820b704784aff695e0019309ad446a6d0b065b57e4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.19.4"
+        },
+        "opencv-python": {
+            "hashes": [
+                "sha256:30edebc81b260bcfeb760b3600c367c5261dfb2fe41e5d1408d5357d0867b40d",
+                "sha256:32dee1c9fd3e31e28edef7b56f868e2b40e280b7062304f9fb8a14dbc51547d5",
+                "sha256:4982fa8ccc38310a2bd93e06334ba090b12b6aff2f6fcb8ff9613e3c9bc48f48",
+                "sha256:5172cb37dfd8a0b4945b071a493eb36e5f17675a160637fa380f9c1d9d80535c",
+                "sha256:6d8434a45e8f75c4da5fd0068ce001f4f8e35771cc851d746d4721eeaf517e25",
+                "sha256:78a6db8467639383caedf1d111da3510a4ee1a0aacf2117821cae2ee8f92ce37",
+                "sha256:9646875c501788b1b098f282d777b667d6da69801739504f1b2fd1268970d1da",
+                "sha256:9c77d508e6822f1f40c727d21b822d017622d8305dce7eccf0ab06caac16d5c6",
+                "sha256:a1dfa0486db367594510c0c799ec7481247dc86e651b69008806d875ab731471",
+                "sha256:b2b9ac86aec5f2dd531545cebdea1a1ef4f81ef1fb1760d78b4725f9575504f9",
+                "sha256:bcb27773cfd5340b2b599b303d9f5499838ef4780c20c038f6030175408c64df",
+                "sha256:c0503bfaa2b7b743d6ff5d81f1dd8428dbf4c33e7e4f836456d11be20c2e7721",
+                "sha256:c1159d91f29a85c3333edef6ca420284566d9bcdae46dda2fe7282515b48c8b6",
+                "sha256:c4ea4f8b217f3e8be6247fc0787fb81797d85202c722523f41070124a7a621c7",
+                "sha256:c8cc1f5ff3c352ebe756119014c4e4ec7ae5ac536d1f66b0316667ced37637c8",
+                "sha256:d16144c435b816c5536d5ff012c1a2b7e93155017db7103942ff7efb98c4df1f",
+                "sha256:d8aefcb30b71064dbbaa2b0ace161a36464c29375a83998fbda39a1d1740f942",
+                "sha256:e27d062fa1098d90f48b6c047351c89816492a08906a021c973ce510b04a7b9d",
+                "sha256:e2c17714da59d9d516ceef0450766ff9557ee232d62f702665af905193557582",
+                "sha256:e38fbd7b2db03204ec09930609b7313d6b6d2b271c8fe2c0aa271fa69b726a1b",
+                "sha256:e77d0feaff37326f62b127098264e2a7099deb476e38432b1083ce11cdedf560",
+                "sha256:ebe83901971a6755512424c4fe9f63341cca501b7c497bf608dd38ee31ba3f4c",
+                "sha256:efac9893d9e21cfb599828801c755ecde8f1e657f05ec6f002efe19422456d5a",
+                "sha256:fc1472b825d26c8a4f1cfb172a90c3cc47733e4af7522276c1c2efe8f6006a8b",
+                "sha256:ffc75c614b8dc3d8102f3ba15dafd6ec0400c7ffa71a91953d41511964ee50e0"
+            ],
+            "index": "pypi",
+            "version": "==4.5.1.48"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
+                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.20"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ room, but I bet it doesn't work for you, or you must have the same lighting and 
 # Installation
 Start off by cloning:
 ```
-$ git clone https://github.com/muts/qbr.git
+$ git clone https://github.com/kkoomen/qbr.git
 $ cd qbr/qbr/
 ```
 

--- a/README.md
+++ b/README.md
@@ -140,4 +140,4 @@ B2 U2 F' R U D' L' B' U L F U F2 R2 F2 D' F2 D R2 D2 (20 moves)
 
 qbr is licensed under the MIT License.
 
-Copyright (c) muts.
+Copyright (c) Kim Koomen.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 A rubik's cube solver written in python 3 using OpenCV using your webcam.
 
 NOTE: qbr uses color detection and color detection is insanely hard to fix for
-every possible situation, because certain light influences a color detector and the
+every possible situation, because certain light influences a color detector, and the
 color scheme on a rubik's cube.
 The color detection in qbr is based on my color scheme which is a mid-bright scheme from
-the [Gans365](http://thecubicle.us/images/gans56b3.jpg) and in a room with normal day light.
+the [Gans365](http://thecubicle.us/images/gans56b3.jpg) and in a room with normal daylight.
 
 # Table of Contents
 - [Introduction](#introduction)
+- [Prerequisites](#prerequisites-relevant-only-when-using-pipenv)
 - [Installation](#installation)
+- [Pulling Dependencies](#pulling-dependencies)
 - [Usage](#usage)
-    - [Paramaters](#paramaters)
+    - [Parameters](#parameters)
 - [License](#license)
 
 
@@ -28,19 +30,55 @@ That inspired me to create my own. I started using images only and eventually sw
 One of the main things that killed me during developing this was color detection. It works for my
 room, but I bet it doesn't work for you, or you must have the same lighting and color scheme as I do.
 
+# Prerequisites (relevant only when using pipenv)
+You will need to install `pipenv` on your machine as well as have python 3.7 installed.
+#### Installing pipenv: ([Full Guide](https://pypi.org/project/pipenv/))
+```
+$ sudo apt install pipenv
+```
+
+NOTE: If you have (and need also) an earlier than 3.7 version of python installed, you might need to used [pyenv](https://github.com/pyenv/pyenv-installer) to manage multiple python versions on your machine.
+
 # Installation
-Start off by cloning:
+###Start off by cloning:
 ```
 $ git clone https://github.com/kkoomen/qbr.git
-$ cd qbr/qbr/
+$ cd qbr
+```
+
+# Pulling Dependencies
+###Manually installing deps:
+```
+$ pip install opencv-python
+$ pip install kociemba
+```
+
+###Using requirements.txt:
+```
+$ pip install -r requirements.txt
+```
+
+###If using pipenv (and making it virtual):
+```
+$ pipenv sync
 ```
 
 # Usage
+###Run qbr:
 
-Run qbr:
-
+####Running without a virtual-env (i.e. w/o pipenv)
 ```
-$ ./qbr.py
+$ python ./src/qbr.py
+```
+
+####Running with a virtual-env using pipenv
+```
+$ pipenv run ./src/qbr.py
+
+OR
+
+$ pipenv shell
+$ python ./src/qbr.py
 ```
 
 This opens a webcam interface where you see basically the above photo.
@@ -78,7 +116,7 @@ solve it if you've scanned it in correctly.
 
 You should now see a solution (or an error if you did it wrong).
 
-# Paramaters
+# Parameters
 
 You can use `-n` or `--normalize` to also output the solution in a "human-readable" format.
 
@@ -88,14 +126,14 @@ For example:
 * `F2` will be: `Turn the front face 180 degrees.`
 
 You can also specify a language by passing in `-l` or `--language`. Default language
-is set to `en`. The only language other then english that is available is dutch which
+is set to `en`. The only language other than english that is available is Dutch which
 is specified with `nl`.
 
 
-#### Test runs I've done:
+### Test runs I've done:
 
 ```
-$ ./qbr.py
+$ python ./src/qbr.py
 -- SOLUTION --
 Starting position:
     front: green
@@ -105,7 +143,7 @@ U2 R D2 L2 F2 L U2 L F' U L U R2 B2 U' F2 D2 R2 D2 R2 (20 moves)
 ```
 
 ```
-$ ./qbr.py -n
+$ python ./src/qbr.py -n
 -- SOLUTION --
 Starting position:
     front: green

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+-i https://pypi.org/simple
+cffi==1.14.4
+future==0.18.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
+kociemba==1.2.1
+numpy==1.19.4; python_version >= '3.6'
+opencv-python==4.5.1.48
+pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -i https://pypi.org/simple
 cffi==1.14.4
-future==0.18.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
+future==0.18.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 kociemba==1.2.1
-numpy==1.19.4; python_version >= '3.6'
+numpy==1.19.5
 opencv-python==4.5.1.48
 pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'

--- a/src/colordetection.py
+++ b/src/colordetection.py
@@ -5,22 +5,29 @@
 # Created       : Tue, 26 Jan 2016
 # Last Modified : Sun, 31 Jan 2016
 
+# Built-ins
+from sys import exit as die
+from typing import Tuple
 
-from sys import exit as Die
+# 3rd Party
 try:
-    import sys
+    from numpy import ndarray as np_ndarray     # type: ignore
 except ImportError as err:
-    Die(err)
+    np_ndarray = None
+    die(err)
+
 
 class ColorDetection:
 
-    def get_color_name(self, hsv):
-        """ Get the name of the color based on the hue.
-
-        :returns: string
+    @staticmethod
+    def get_color_name(hsv: Tuple[int, int, int]) -> str:
         """
-        (h,s,v) = hsv
-        #print((h,s,v))
+        Get the name of the color based on the hue.
+
+        :param hsv: An HSV tuple
+        :returns: The name of the color
+        """
+        (h, s, v) = hsv
         if h < 15 and v < 100:
             return 'red'
         if h <= 10 and v > 100:
@@ -36,7 +43,8 @@ class ColorDetection:
 
         return 'white'
 
-    def name_to_rgb(self, name):
+    @staticmethod
+    def name_to_rgb(name: str) -> Tuple[int, int, int]:
         """
         Get the main RGB color for a name.
 
@@ -44,25 +52,23 @@ class ColorDetection:
         :returns: tuple
         """
         color = {
-            'red'    : (0,0,255),
-            'orange' : (0,165,255),
-            'blue'   : (255,0,0),
-            'green'  : (0,255,0),
-            'white'  : (255,255,255),
-            'yellow' : (0,255,255)
+            'red':      (0, 0, 255),
+            'orange':   (0, 165, 255),
+            'blue':     (255, 0, 0),
+            'green':    (0, 255, 0),
+            'white':    (255, 255, 255),
+            'yellow':   (0, 255, 255)
         }
         return color[name]
 
-    def average_hsv(self, roi):
+    @staticmethod
+    def average_hsv(roi: np_ndarray) -> Tuple[int, int, int]:
         """ Average the HSV colors in a region of interest.
 
         :param roi: the image array
         :returns: tuple
         """
-        h   = 0
-        s   = 0
-        v   = 0
-        num = 0
+        h, s, v, num = (0.0, 0.0, 0.0, 0)
         for y in range(len(roi)):
             if y % 10 == 0:
                 for x in range(len(roi[y])):
@@ -75,6 +81,7 @@ class ColorDetection:
         h /= num
         s /= num
         v /= num
-        return (int(h), int(s), int(v))
+        return int(h), int(s), int(v)
 
-ColorDetector = ColorDetection()
+
+color_detector = ColorDetection()

--- a/src/combiner.py
+++ b/src/combiner.py
@@ -5,11 +5,15 @@
 # Created       : Tue, 26 Jan 2016
 # Last Modified : Sat, 30 Jan 2016
 
+from typing import List, Dict
+
 
 class Combine:
 
-    def sides(self, sides):
-        """Join all the sides together into one single string.
+    @staticmethod
+    def sides(sides: Dict[str, List[str]]) -> str:
+        """
+        Join all the sides together into one single string.
 
         :param sides: dictionary with all the sides
         :returns: string
@@ -18,5 +22,6 @@ class Combine:
         for face in 'URFDLB':
             combined += ''.join(sides[face])
         return combined
+
 
 combine = Combine()

--- a/src/normalizer.py
+++ b/src/normalizer.py
@@ -5,22 +5,19 @@
 # Created       : Sat, 30 Jan 2016
 # Last Modified : Mon, 01 Feb 2016
 
-
-from sys import exit as Die
-try:
-    import sys
-    import json
-except ImportError as err:
-    Die(err)
+import json
+from typing import List
 
 
 class Normalizer:
 
-    def algorithm(self, alg, language):
-        """ Noramlize an algorithm from the
-        json-written manual.
+    @staticmethod
+    def algorithm(alg: str, language: str) -> List[str]:
+        """
+        Normalize an algorithm from the json-written manual.
 
         :param alg: The algorithm itself
+        :param language: Language symbol
         :returns: list
         """
         with open('solve-manual.json') as f:
@@ -30,5 +27,6 @@ class Normalizer:
         for notation in alg.split(' '):
             solution.append(manual[language][notation])
         return solution
+
 
 normalize = Normalizer()

--- a/src/qbr.py
+++ b/src/qbr.py
@@ -5,62 +5,70 @@
 # Created       : Tue, 26 Jan 2016
 # Last Modified : Sun, 31 Jan 2016
 
+# Built-ins
+from sys import exit as die
+import argparse
+from typing import Union, List
 
-from sys import exit as Die
+# 3rd Party
 try:
-    import sys
-    import kociemba
-    import argparse
-
-    from combiner import combine
-    from video import webcam
-    from normalizer import normalize
+    import kociemba     # type: ignore
 except ImportError as err:
-    Die(err)
+    kociemba = None
+    die(err)
+
+# Internals
+from combiner import combine
+from video import webcam
+from normalizer import normalize
 
 
 class Qbr:
 
-    def __init__(self, normalize, language):
-        self.humanize = normalize
+    def __init__(self,
+                 do_normalize: bool,
+                 language: Union[List[str], str]):
+        self.humanize = do_normalize
         self.language = (language[0]) if isinstance(language, list) else language
 
     def run(self):
-        state         = webcam.scan()
-        if not state:
+        state = webcam.scan()
+        if state is None:
             print('\033[0;33m[QBR SCAN ERROR] Ops, you did not scan in all 6 sides.')
             print('Please try again.\033[0m')
-            Die(1)
+            die(1)
 
-        unsolvedState = combine.sides(state)
+        unsolved_state = combine.sides(state)
         try:
-            algorithm     = kociemba.solve(unsolvedState)
-            length        = len(algorithm.split(' '))
-        except Exception as err:
+            algorithm = kociemba.solve(unsolved_state)
+            length = len(algorithm.split(' '))
+        except Exception:
             print('\033[0;33m[QBR SOLVE ERROR] Ops, you did not scan in all 6 sides correctly.')
             print('Please try again.\033[0m')
-            Die(1)
+            die(1)
+        else:
+            print('-- SOLUTION --')
+            print('Starting position:\n    front: green\n    top: white\n')
+            print(algorithm, '({0} moves)'.format(length), '\n')
 
-        print('-- SOLUTION --')
-        print('Starting position:\n    front: green\n    top: white\n')
-        print(algorithm, '({0} moves)'.format(length), '\n')
+            if self.humanize:
+                manual = normalize.algorithm(algorithm, self.language)
+                for index, text in enumerate(manual):
+                    print('{}. {}'.format(index+1, text))
+        die(0)
 
-        if self.humanize:
-            manual = normalize.algorithm(algorithm, self.language)
-            for index, text in enumerate(manual):
-                print('{}. {}'.format(index+1, text))
-        Die(0)
 
 if __name__ == '__main__':
     # define argument parser.
     parser = argparse.ArgumentParser()
-    parser.add_argument('-n', '--normalize', default=False, action='store_true',
-            help='Shows the solution normalized. For example "R2" would be: \
-                    "Turn the right side 180 degrees".')
-    parser.add_argument('-l', '--language', nargs=1, default='en',
-            help='You can pass in a single \
-                    argument which will be the language for the normalization output. \
-                    Default is "en".')
+    parser.add_argument(
+        '-n', '--normalize', default=False, action='store_true',
+        help='Shows the solution normalized. For example "R2" would be: Turn '
+             'the right side 180 degrees".')
+    parser.add_argument(
+        '-l', '--language', nargs=1, default='en',
+        help='You can pass in a single argument which will be the language for'
+             ' the normalization output. Default is "en".')
     args = parser.parse_args()
 
     # run Qbr with its arguments.


### PR DESCRIPTION
Mostly PEP8 and Mypy (typing) related touch-ups as well as some PyCharm-Inspection touch-ups and finally a few additional ones.

Also, due to full type-hinting support, had to expose/import "ndarray" from `numpy` which is used in OpenCV's APIs. `numpy` was anyway an indirect dependency and not it has become a direct dependency. Pipefile(s) have been updated and `requirements.txt` has been re-generated (`via pipenv lock -r > requirements.txt`).

In high-level, these are the main (PEP8/Mypy) changes:
  1) Handing import in general-to-specific order
  2) Removed exception handling for imports of built-ins and internal modules
  3) Made static-able methods `@staticmehtod`(s)
  4) Add Type-Hinting
  5) Shorten too-long lines
  6) Many "x,y,z" cases replaced with "x, y, z"

**NOTE1:** After this PR, code now is PyCharm-Inspection and Mypy warning/error free
**NOTE2:** PR is based on https://github.com/kkoomen/qbr/pull/6 due to the need to update the `numpy` dependency in the Pipfile(s) and re-generate the `requirements.txt`.